### PR TITLE
Improve kopsAws and okebmc unit tests and add back goreport badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Go Report Card](https://goreportcard.com/badge/github.com/oracle/cluster-manager)](https://goreportcard.com/report/github.com/oracle/cluster-manager)
+
 # Cluster Manager
 
 Cluster Manager manages the life cycle of Kubernetes clusters from different cloud providers.

--- a/pkg/controller/cluster/provider/kopsAws/kops_test.go
+++ b/pkg/controller/cluster/provider/kopsAws/kops_test.go
@@ -363,6 +363,8 @@ func TestNewAwsKops(t *testing.T) {
 	defaultMasterZonesStr := "us-west-1a, us-west-2a"
 	defaultMasterZones := strings.Split(defaultMasterZonesStr, ",")
 	for _, test := range tests {
+		os.Unsetenv(AWSAccessKeyId)
+		os.Unsetenv(AWSSecretAccessKeyId)
 		for _, accessKeyId := range test.accessKeyIds {
 			os.Setenv(accessKeyId, accessKeyId)
 		}
@@ -372,8 +374,6 @@ func TestNewAwsKops(t *testing.T) {
 			DefaultNodeZones:   defaultNodeZonesStr,
 			KopsStateStore:     test.kopsStateStore,
 		})
-		os.Unsetenv(AWSAccessKeyId)
-		os.Unsetenv(AWSSecretAccessKeyId)
 		if test.expectsSuccess {
 			if err != nil {
 				t.Errorf("NewAwsKops expects no error, but got one: %s!", err)

--- a/pkg/controller/cluster/provider/oke/okebmc_test.go
+++ b/pkg/controller/cluster/provider/oke/okebmc_test.go
@@ -56,6 +56,9 @@ func TestNewOke(t *testing.T) {
 		{accessKeyIdsOne2, false},
 	}
 	for _, testData := range tests {
+		for _, accessKeyId := range accessKeyIdsAll {
+			os.Unsetenv(accessKeyId)
+		}
 		for _, accessKeyId := range testData.accessKeyIds {
 			os.Setenv(accessKeyId, accessKeyId)
 		}
@@ -75,9 +78,6 @@ func TestNewOke(t *testing.T) {
 			}
 		} else if err == nil {
 			t.Errorf("OKE expects error, but did not get one!")
-		}
-		for _, accessKeyId := range testData.accessKeyIds {
-			os.Unsetenv(accessKeyId)
 		}
 	}
 }


### PR DESCRIPTION
Change kopsAws and okebmc unit tests to avoid problems when certain environment variables are already set. Also add back the badge for goreport.