### PR TITLE
Update Readme doc instructions and update deployment yaml files

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,7 +23,7 @@ environment variables.
     export FEDERATION_HOST=fedhost
     export FEDERATION_CONTEXT=akube
     export FEDERATION_NAMESPACE=federation-system
-    export CLUSTER_MANAGER_IMAGE=/docker.io/somewhere/cluster-manager:v1
+    export CLUSTER_MANAGER_IMAGE=/docker.io/somewhere/cluster-manager:tagversion
     export AWS_ACCESS_KEY_ID=awsaccesskeyid
     export AWS_SECRET_ACCESS_KEY=awssecretaccesskey
     export OKE_BEARER_TOKEN=werckerclustersbearertoken
@@ -74,11 +74,10 @@ deploy directory or may refer to the helm chart in the deploy directory.
         --set federationContext="$FEDERATION_CONTEXT" \
         --set federationNamespace="$FEDERATION_NAMESPACE" \
         --set domain="something.fed.net" \
-        --set image.repository="docker.io/somewhere/cluster-manager" \
+        --set image.repository="docker.io/somewhere/" \
         --set image.tag="v1" \
         --set okeApiHost="api.cluster.us-ashburn-1.oracledx.com" \
         --set statestore="s3://clusters-state" \
-        --namespace "$FEDERATION_NAMESPACE" \
         --kube-context "$FEDERATION_HOST"
     ```  
         Where, 
@@ -111,6 +110,8 @@ deploy directory or may refer to the helm chart in the deploy directory.
     helm delete --kube-context $FEDERATION_HOST --purge cluster-manager
     ```
 
+## Examples on how to use Cluster Manager
+
 ## Provisioning a Wercker Cluster
 
 1. Deploy a Wercker Cluster to the Federation, use [`ClusterOke.yaml`](../examples/ClusterOke.yaml) from
@@ -134,8 +135,6 @@ examples.
         ```
         kubectl --context=$FEDERATION_HOST annotate cluster akube-oke n6s.io/cluster.lifecycle.state=pending-provision --overwrite
         ```
-
-## Examples on how to use Cluster Manager
 
 ### Provisioning an AWS Cluster
 
@@ -210,3 +209,17 @@ Here is an example of shutting down a previously provisioned `akube-us-east-2` A
     ```
     kubectl --context=$FEDERATION_HOST annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-shutdown --overwrite
     ```
+
+### Checking cluster status
+
+- To check the status of a specific cluster, execute the command and note the value of `n6s.io/cluster.lifecycle.state` annotation.
+
+    ```
+    kubectl --context=$FEDERATION_HOST get cluster <Cluster Name> -o yaml
+    ``` 
+    
+- To check the status of all the clusters, execute the command and note the value of `n6s.io/cluster.lifecycle.state` annotation for each of the clusters listed .
+
+    ```
+    kubectl --context=$FEDERATION_HOST get clusters -o yaml
+    ```    

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -112,7 +112,7 @@ deploy directory or may refer to the helm chart in the deploy directory.
 
 ## Examples on how to use Cluster Manager
 
-## Provisioning a Wercker Cluster
+### Provisioning a Wercker Cluster
 
 1. Deploy a Wercker Cluster to the Federation, use [`ClusterOke.yaml`](../examples/ClusterOke.yaml) from
 examples.

--- a/deploy/WerckerClustersParameters.md
+++ b/deploy/WerckerClustersParameters.md
@@ -1,20 +1,16 @@
-# Retrieving Wercker Clusters parameters
+# Setting up Wercker Clusters parameters to work with Cluster Manager
 
-1. Create Cloud Credential. Use this information for the cluster-manager's OKE_CLOUD_AUTH_ID:
-   1. Go to https://app.wercker.com/clusters/cloud-credentials
-   1. Choose which Organization to use for the Cloud Credential
-   1. Click "New Cloud Credential Button"
-   1. Provide a Name
-   1. Add all your BMC/OCI tenancy specific information (User OCID, Tenancy OCID). Get those information by logging in to OCI: https://console.us-phoenix-1.oraclecloud.com/ and then change Region to us-ashburn-1. Go to Identity to get User OCID. At the bottom of any page in OCI, you can get the Tenancy ID.
-   1. For Key Fingerprint and API Private Key (PEM Format), follow the instruction in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm .
-   1. Once all the required information is inputted, click create and take note of the cloud credential.
-   1. The cloud credential can also be retrieved by going to Clusters->Cloud Credentials, choose the Organization and the name of your credential. From there the Cloud Auth Id can be retrieved.
-1. To get the token that will be used for OKE_BEARER_TOKEN: 
-   1. Click user icon on the top right corner of the app.wercker window.
-   1. Choose Settings->Personal Tokens and generate a new token.
-   1. Once the token is displayed, make sure to copy it as it won't be shown again.
-1. To get the OKE_AUTH_GROUP
-    1. Use this rest request ```curl -L app.wercker.com/api/v3/identity/lookup?q=<GROUP Name>```
-    1. For example ```curl -L app.wercker.com/api/v3/identity/lookup?q=GAS{"id":"59cae3bd1521710100bc1449","name":"GAS"}```
-    1. The id field value ("59cae3bd1521710100bc1449") reflects OKE_AUTH_GROUP
-1. When logged in to the OCI console, also take note of the Compartment ID. Go to Identity->Compartment and choose the compartment where the instances will be created. Use this information in the cluster's cluster-manager.n6s.io/cluster.config annotation to specify which compartment will be used by the cluster.
+If you are using [Wercker Clusters](http://devcenter.wercker.com/docs/getting-started-with-wercker-clusters#creatingcluster), you need to set the *OKE_CLOUD_AUTH_ID*,  *OKE_BEARER_TOKEN*,  *OKE_AUTH_GROUP*,  and Compartment ID parameters to work with Cluster Manager. If you do not have these parameters, then follow this document to create them.  
+
+1. When you use Wercker Clusters to create a new Kubernetes cluster, you specify Cloud Credentials to specify where you want to create the cluster. If you already have *Cloud Auth ID* and OKE_AUTH_GROUP in the **Clusters > Cloud Credentials** page in the Wercker cluster, you can use those credentials. If you have to create those IDs, then follow these steps:
+<ol type="a">
+<li>Go to https://app.wercker.com/clusters/cloud-credentials and select the Organization.</li>
+<li>Click **New Cloud Credential Button**. </li>
+<li>Enter a name.</li>
+<li>Enter all your Oracle Cloud Infrastructure (OCI) tenancy specific information (User OCID, Tenancy OCID). You can get those information by logging in to [OCI](https://console.us-phoenix-1.oraclecloud.com/) and then by changing the Region, for example, change the region to *us-ashburn-1*. Navigate to Identity and note down the User OCID and also copy the Tenancy ID, which you will find at the bottom of any page in OCI.</li>
+<li>For **Key Fingerprint** and **API Private Key (PEM Format)**, follow the instructions in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.</li>
+<li> Click **Create** and note down the Cloud Auth ID. The Cloud_Auth_ID is displayed in the Cloud Credentials page.</li>
+<li>In the Cloud Credentials page, note down the OKE_AUTH_GROUP, which is the ID displayed next to the Organization drop down list. 
+</ol>
+2. Create a new Wercker authentication token if you do not have one, which will be used for *OKE_BEARER_TOKEN*. See [how to get a Wercker authentication token] (http://devcenter.wercker.com/docs/getting-started-with-wercker-releases#gettingtoken) for more details.
+3. You also need a Compartment ID to specify which compartment the cluster will use. When you log in to the OCI console, go to Identity->Compartment and choose the compartment where the instances will be created. 

--- a/deploy/helm/cluster-manager/templates/deployment.yaml
+++ b/deploy/helm/cluster-manager/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "name" . }}
-  namespace: {{ .Values.federationHostNamespace }}
+  namespace: {{ .Values.federationNamespace }}
 spec:
   replicas: 1
   template:

--- a/examples/ClusterManager.yaml
+++ b/examples/ClusterManager.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: cluster-manager
-  namespace: federation-system
+  namespace: $FEDERATION_NAMESPACE
 spec:
   replicas: 1
   template:


### PR DESCRIPTION
1. Update Wercker instructions doc
2. Update deploy readme to add steps for checking the status of the cluster and remove --namespace option from helm instruction as this is already set in the deployment.yaml of the helm.
3. Update deployment.yaml of helm to set the metadata.namespace to the federation namespace variable.
4. Update ClusterManager.yaml to set the metadata.namespace to the federation env variable.