### PR TITLE
Use Secrets to store Provider API access keys  and Update docs

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,7 +23,7 @@ environment variables.
     export FEDERATION_HOST=fedhost
     export FEDERATION_CONTEXT=akube
     export FEDERATION_NAMESPACE=federation-system
-    export CLUSTER_MANAGER_IMAGE=/docker.io/somewhere/cluster-manager:v1
+    export CLUSTER_MANAGER_IMAGE=/docker.io/somewhere/cluster-manager:tagversion
     export AWS_ACCESS_KEY_ID=awsaccesskeyid
     export AWS_SECRET_ACCESS_KEY=awssecretaccesskey
     export OKE_BEARER_TOKEN=werckerclustersbearertoken
@@ -74,11 +74,10 @@ deploy directory or may refer to the helm chart in the deploy directory.
         --set federationContext="$FEDERATION_CONTEXT" \
         --set federationNamespace="$FEDERATION_NAMESPACE" \
         --set domain="something.fed.net" \
-        --set image.repository="docker.io/somewhere/cluster-manager" \
+        --set image.repository="docker.io/somewhere/" \
         --set image.tag="v1" \
         --set okeApiHost="api.cluster.us-ashburn-1.oracledx.com" \
         --set statestore="s3://clusters-state" \
-        --namespace "$FEDERATION_NAMESPACE" \
         --kube-context "$FEDERATION_HOST"
     ```  
         Where, 
@@ -111,6 +110,8 @@ deploy directory or may refer to the helm chart in the deploy directory.
     helm delete --kube-context $FEDERATION_HOST --purge cluster-manager
     ```
 
+## Examples on how to use Cluster Manager
+
 ## Provisioning a Wercker Cluster
 
 1. Deploy a Wercker Cluster to the Federation, use [`ClusterOke.yaml`](../examples/ClusterOke.yaml) from
@@ -134,8 +135,6 @@ examples.
         ```
         kubectl --context=$FEDERATION_HOST annotate cluster akube-oke n6s.io/cluster.lifecycle.state=pending-provision --overwrite
         ```
-
-## Examples on how to use Cluster Manager
 
 ### Provisioning an AWS Cluster
 
@@ -210,3 +209,17 @@ Here is an example of shutting down a previously provisioned `akube-us-east-2` A
     ```
     kubectl --context=$FEDERATION_HOST annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-shutdown --overwrite
     ```
+
+### Checking cluster status
+
+- To check the status of a specific cluster, execute the command and note the value of `n6s.io/cluster.lifecycle.state` annotation.
+
+    ```
+    kubectl --context=$FEDERATION_HOST get cluster <Cluster Name> -o yaml
+    ``` 
+    
+- To check the status of all the clusters, execute the command and note the value of `n6s.io/cluster.lifecycle.state` annotation for each of the clusters listed .
+
+    ```
+    kubectl --context=$FEDERATION_HOST get clusters -o yaml
+    ```    

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -164,7 +164,7 @@ from examples.
     - At the end of the provisioning, the value of `n6s.io/cluster.lifecycle.state` will be changed either to `ready` if successful or `failed-up` if failed. 
 
     ```
-    kubectl --context=$FEDERATION_HOST annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-provision --overwrite
+    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-provision --overwrite
     ```
 
 ### Scaling up an already provisioned cluster
@@ -178,8 +178,8 @@ from examples.
 Here is an example of scaling up a previously provisioned `akube-us-east-2` AWS cluster by 5
 
     ```
-    kubectl --context=$FEDERATION_HOST annotate cluster akube-us-east-2 cluster-manager.n6s.io/cluster.scale-up-size=5 --overwrite && \
-    kubectl --context=$FEDERATION_HOST annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-up --overwrite
+    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 cluster-manager.n6s.io/cluster.scale-up-size=5 --overwrite && \
+    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-up --overwrite
     ```
 
 ### Scaling down an already provisioned cluster
@@ -193,8 +193,8 @@ Here is an example of scaling up a previously provisioned `akube-us-east-2` AWS 
 Here is an example of scaling down a previously provisioned `akube-us-east-2` AWS cluster by 5
 
     ```
-    kubectl --context=$FEDERATION_HOST annotate cluster akube-us-east-2 cluster-manager.n6s.io/cluster.scale-down-size=5 --overwrite && \
-    kubectl --context=$FEDERATION_HOST annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-down --overwrite
+    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 cluster-manager.n6s.io/cluster.scale-down-size=5 --overwrite && \
+    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-down --overwrite
     ```
 
 ### Shutting down a provisioned cluster
@@ -207,7 +207,7 @@ Here is an example of scaling down a previously provisioned `akube-us-east-2` AW
 Here is an example of shutting down a previously provisioned `akube-us-east-2` AWS cluster
 
     ```
-    kubectl --context=$FEDERATION_HOST annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-shutdown --overwrite
+    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-shutdown --overwrite
     ```
 
 ### Checking cluster status
@@ -215,11 +215,11 @@ Here is an example of shutting down a previously provisioned `akube-us-east-2` A
 - To check the status of a specific cluster, execute the command and note the value of `n6s.io/cluster.lifecycle.state` annotation.
 
     ```
-    kubectl --context=$FEDERATION_HOST get cluster <Cluster Name> -o yaml
+    kubectl --context=$FEDERATION_CONTEXT get cluster <Cluster Name> -o yaml
     ``` 
     
 - To check the status of all the clusters, execute the command and note the value of `n6s.io/cluster.lifecycle.state` annotation for each of the clusters listed .
 
     ```
-    kubectl --context=$FEDERATION_HOST get clusters -o yaml
+    kubectl --context=$FEDERATION_CONTEXT get clusters -o yaml
     ```    

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,7 @@ you can use a bash script to set the required environment variables and generate
     ```
     #!/bin/bash
     
+    # Set environment variables 
     export FEDERATION_HOST=fedhost
     export FEDERATION_CONTEXT=akube
     export FEDERATION_NAMESPACE=federation-system
@@ -35,20 +36,20 @@ you can use a bash script to set the required environment variables and generate
     export OKE_AUTH_GROUP=werckerclustersauthgroup
     export OKE_CLOUD_AUTH_ID=werckerclusterscloudauthid
      
-    # Convert API access keys to base64 for K8s secret storage 
+    # Convert API access keys to base64 for Kubernetes secret storage.
     export AWS_ACCESS_KEY_ID_BASE64=$(echo -n "$AWS_ACCESS_KEY_ID" | base64)
     export AWS_SECRET_ACCESS_KEY_BASE64=$(echo -n "$AWS_SECRET_ACCESS_KEY" | base64)
     export OKE_BEARER_TOKEN_BASE64=$(echo -n "$OKE_BEARER_TOKEN" | base64)
     export OKE_AUTH_GROUP_BASE64=$(echo -n "$OKE_AUTH_GROUP" | base64)
     export OKE_CLOUD_AUTH_ID_BASE64=$(echo -n "$OKE_CLOUD_AUTH_ID" | base64)
      
-    # Generate a new ClusterManager.yaml using ClusterManagerTemplate.yaml and above env. variables
+    # Generate a new ClusterManager.yaml by using ClusterManagerTemplate.yaml and environment variables.
     eval "cat <<EOF
     $(<ClusterManagerTemplate.yaml)
     EOF" > ClusterManager.yaml  
     ```
 
-1. Use `kubectl` to deploy the generated `ClusterManager.yaml`.
+1. Use `kubectl` to deploy the generated `ClusterManager.yaml` file.
      
     ``` 
     kubectl --context $FEDERATION_HOST create -f ClusterManager.yaml
@@ -99,23 +100,23 @@ deploy directory or may refer to the helm chart in the deploy directory.
         --set statestore="s3://clusters-state" \
         --kube-context "$FEDERATION_HOST"
     ```  
-        Where, 
-        * `FEDERATION_NAMESPACE` - Namespace where federation was installed via kubefed init
-        * `FEDERATION_HOST` - Federation host name
-        * `FEDERATION_CONTEXT` - Federation context name
-        * `awsAccessKeyId` - AWS access key ID
-        * `awsSecretAccessKey` - AWS secret access ID
-        * `okeBearerToken`- Wercker Clusters bearer token
-        * `okeAuthGroup` - Wercker Clusters auth group
-        * `okeCloudAuthId` - Wercker Clusters cloud auth ID
-        * `federationEndpoint` - Federation API server endpoint
-        * `federationContext` - Federation name
-        * `federationNamespace` - Similar to FEDERATION_NAMESPACE. Defaults to federation-system if not set.
-        * `domain` - AWS domain name
-        * `image.repository` - Repository where Cluster Manager is stored
-        * `image.tag` - Cluster Manager image tag/version no.
-        * `okeApiHost` - Wercker Clusters API host endpoint
-        * `statestore` - AWS cluster S3 state store
+    Where, 
+    * `FEDERATION_NAMESPACE` - Namespace where federation was installed via kubefed init
+    * `FEDERATION_HOST` - Federation host name
+    * `FEDERATION_CONTEXT` - Federation context name
+    * `awsAccessKeyId` - AWS access key ID
+    * `awsSecretAccessKey` - AWS secret access ID
+    * `okeBearerToken`- Wercker Clusters bearer token
+    * `okeAuthGroup` - Wercker Clusters auth group
+    * `okeCloudAuthId` - Wercker Clusters cloud auth ID
+    * `federationEndpoint` - Federation API server endpoint
+    * `federationContext` - Federation name
+    * `federationNamespace` - Similar to FEDERATION_NAMESPACE. Defaults to federation-system if not set.
+    * `domain` - AWS domain name
+    * `image.repository` - Repository where Cluster Manager is stored
+    * `image.tag` - Cluster Manager image tag/version no.
+    * `okeApiHost` - Wercker Clusters API host endpoint
+    * `statestore` - AWS cluster S3 state store
 
 3. Verify if Cluster Manager is installed.
 
@@ -141,11 +142,11 @@ examples.
     ```
     This command deploys the cluster in an offline state. To customize the Wercker cluster, change the parameters in `cluster-manager.n6s.io/cluster.config` annotation of cluster. Before deploying, you can modify *ClusterOke.yaml* or use `kubectl` annotate command. The supported parameters are
 
-        - K8Version - Kubernetes Version. Valid values are 1.7.4, 1.7.9, or 1.8.0. Default value  is 1.7.4.
-        - nodeZones - Available Domains. Valid values are AD-1, AD-2, AD-3. This field can be set to any combination of the set of values.
-        - shape - Valid values are VM.Standard1.1, VM.Standard1.2, VM.Standard1.4, VM.Standard1.8, VM.Standard1.16, VM.DenseIO1.4, VM.DenseIO1.8, VM.DenseIO1.16, BM.Standard1.36, BM.HighIO1.36 and BM.DenseIO1.36. 
-        - workersPerAD - No. of worker nodes per availability domain.
-        - compartment - Wercker Cluster Compartment ID where worker nodes will be instantiated. 
+    - K8Version - Kubernetes Version. Valid values are 1.7.4, 1.7.9, or 1.8.0. Default value  is 1.7.4.
+    - nodeZones - Available Domains. Valid values are AD-1, AD-2, AD-3. This field can be set to any combination of the set of values.
+    - shape - Valid values are VM.Standard1.1, VM.Standard1.2, VM.Standard1.4, VM.Standard1.8, VM.Standard1.16, VM.DenseIO1.4, VM.DenseIO1.8, VM.DenseIO1.16, BM.Standard1.36, BM.HighIO1.36 and BM.DenseIO1.36. 
+    - workersPerAD - No. of worker nodes per availability domain.
+    - compartment - Wercker Cluster Compartment ID where worker nodes will be instantiated. 
 
 2. Initiate provisioning. **Note:** Do not perform these steps if you are using Navarkos. Navarkos determines on which cluster to perform the operation depending on demand and supply.
     - Update annotation `n6s.io/cluster.lifecycle.state` with value `pending-provision`.  
@@ -169,16 +170,16 @@ from examples.
     `cluster-manager.n6s.io/cluster.config` which is used to customize the cluster, please refer to the 
     [AWS Documentation](https://aws.amazon.com/documentation):
     
-        - region - Region where  the cluster will be instantiated.
-        - masterZones - List of zones where master nodes will be instantiated.
-        - nodeZones - List of zones where worker nodes will be instantiated. 
-        - masterSize - Master node(s) instance size 
-        - nodeSize - Worker node(s) instance size. 
-        - numberOfMasters - No. of master nodes to instantiate.
-        - numberOfNodes - No. of worker nodes to instantiate. 
-        - sshkey - SSH public access key to the cluster nodes.
+    - region - Region where  the cluster will be instantiated.
+    - masterZones - List of zones where master nodes will be instantiated.
+    - nodeZones - List of zones where worker nodes will be instantiated. 
+    - masterSize - Master node(s) instance size 
+    - nodeSize - Worker node(s) instance size. 
+    - numberOfMasters - No. of master nodes to instantiate.
+    - numberOfNodes - No. of worker nodes to instantiate. 
+    - sshkey - SSH public access key to the cluster nodes.
 
-2. Initiate provisioning. **Note:** Do not perform this step if you are using Navarkos. Navarkos determines on which cluster to perform the operation depending on demand and supply.
+1. Initiate provisioning. **Note:** Do not perform this step if you are using Navarkos. Navarkos determines on which cluster to perform the operation depending on demand and supply.
     - Update annotation `n6s.io/cluster.lifecycle.state` with value `pending-provision`.
     - At the end of the provisioning, the value of `n6s.io/cluster.lifecycle.state` will be changed either to `ready` if successful or `failed-up` if failed. 
 
@@ -189,17 +190,16 @@ from examples.
 ### Scaling up an already provisioned cluster
 **Note:** Do not perform these steps if you are using Navarkos. Navarkos determines on which cluster to perform the operation depending on demand and supply.
 
-- If there is more demand, you can scale up an already provisioned cluster to support more load. 
-    Update the annotation `n6s.io/cluster.lifecycle.state` with value `pending-up`. 
+- If there is more demand, you can scale up an already provisioned cluster to support more load. Update the annotation `n6s.io/cluster.lifecycle.state` with value `pending-up`. 
 - You can configure the scale up size using the annotation `cluster-manager.n6s.io/cluster.scale-up-size`, otherwise it uses the default value 1.
 - At the end of the provisioning, the value of `n6s.io/cluster.lifecycle.state` will be changed either to `ready` if successful or `failed-up` if failed. 
 
 Here is an example of scaling up a previously provisioned `akube-us-east-2` AWS cluster by 5
 
-    ```
-    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 cluster-manager.n6s.io/cluster.scale-up-size=5 --overwrite && \
-    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-up --overwrite
-    ```
+```
+kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 cluster-manager.n6s.io/cluster.scale-up-size=5 --overwrite && \
+kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-up --overwrite
+```
 
 ### Scaling down an already provisioned cluster
 **Note:** Do not perform these steps if you are using Navarkos. Navarkos determines on which cluster to perform the operation depending on demand and supply.
@@ -211,23 +211,22 @@ Here is an example of scaling up a previously provisioned `akube-us-east-2` AWS 
 
 Here is an example of scaling down a previously provisioned `akube-us-east-2` AWS cluster by 5
 
-    ```
-    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 cluster-manager.n6s.io/cluster.scale-down-size=5 --overwrite && \
-    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-down --overwrite
-    ```
+```
+kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 cluster-manager.n6s.io/cluster.scale-down-size=5 --overwrite && \
+kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-down --overwrite
+```
 
 ### Shutting down a provisioned cluster
 **Note:** Do not perform these steps if you are using Navarkos. Navarkos determines on which cluster to perform the operation depending on the demand and supply.
 
-- You can shut down a provisioned cluster when it is not in use. 
-    Update annotation `n6s.io/cluster.lifecycle.state` with value `pending-shutdown`. 
+- You can shut down a provisioned cluster when it is not in use. Update annotation `n6s.io/cluster.lifecycle.state` with value `pending-shutdown`. 
 - At the end of the provisioning, the value of `n6s.io/cluster.lifecycle.state` will be changed to `offline`.
 
 Here is an example of shutting down a previously provisioned `akube-us-east-2` AWS cluster
 
-    ```
-    kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-shutdown --overwrite
-    ```
+```
+kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-us-east-2 n6s.io/cluster.lifecycle.state=pending-shutdown --overwrite
+```
 
 ### Checking cluster status
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -118,7 +118,7 @@ deploy directory or may refer to the helm chart in the deploy directory.
 examples.
 
     ```
-    kubectl --context $FEDERATION_HOST create -f ClusterOke.yaml
+    kubectl --context $FEDERATION_CONTEXT create -f ClusterOke.yaml
     ```
     This command deploys the cluster in an offline state. To customize the Wercker cluster, change the parameters in `cluster-manager.n6s.io/cluster.config` annotation of cluster. Before deploying, you can modify *ClusterOke.yaml* or use `kubectl` annotate command. The supported parameters are
 
@@ -133,7 +133,7 @@ examples.
     - At the end of the provisioning, the value of `n6s.io/cluster.lifecycle.state` will be changed either to `ready` if successful or `failed-up` if failed. 
 
         ```
-        kubectl --context=$FEDERATION_HOST annotate cluster akube-oke n6s.io/cluster.lifecycle.state=pending-provision --overwrite
+        kubectl --context=$FEDERATION_CONTEXT annotate cluster akube-oke n6s.io/cluster.lifecycle.state=pending-provision --overwrite
         ```
 
 ### Provisioning an AWS Cluster
@@ -142,7 +142,7 @@ examples.
 from examples.
                                                                                                         
     ```
-    kubectl --context $FEDERATION_HOST create -f ClusterAwsEast2.yaml
+    kubectl --context $FEDERATION_CONTEXT create -f ClusterAwsEast2.yaml
     ```
 
     This command deploys the cluster in an offline state. To customize the AWS cluster, change the parameters in

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -112,7 +112,7 @@ deploy directory or may refer to the helm chart in the deploy directory.
 
 ## Examples on how to use Cluster Manager
 
-## Provisioning a Wercker Cluster
+### Provisioning a Wercker Cluster
 
 1. Deploy a Wercker Cluster to the Federation, use [`ClusterOke.yaml`](../examples/ClusterOke.yaml) from
 examples.

--- a/deploy/WerckerClustersParameters.md
+++ b/deploy/WerckerClustersParameters.md
@@ -1,20 +1,16 @@
-# Retrieving Wercker Clusters parameters
+# Setting up Wercker Clusters parameters to work with Cluster Manager
 
-1. Create Cloud Credential. Use this information for the cluster-manager's OKE_CLOUD_AUTH_ID:
-   1. Go to https://app.wercker.com/clusters/cloud-credentials
-   1. Choose which Organization to use for the Cloud Credential
-   1. Click "New Cloud Credential Button"
-   1. Provide a Name
-   1. Add all your BMC/OCI tenancy specific information (User OCID, Tenancy OCID). Get those information by logging in to OCI: https://console.us-phoenix-1.oraclecloud.com/ and then change Region to us-ashburn-1. Go to Identity to get User OCID. At the bottom of any page in OCI, you can get the Tenancy ID.
-   1. For Key Fingerprint and API Private Key (PEM Format), follow the instruction in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm .
-   1. Once all the required information is inputted, click create and take note of the cloud credential.
-   1. The cloud credential can also be retrieved by going to Clusters->Cloud Credentials, choose the Organization and the name of your credential. From there the Cloud Auth Id can be retrieved.
-1. To get the token that will be used for OKE_BEARER_TOKEN: 
-   1. Click user icon on the top right corner of the app.wercker window.
-   1. Choose Settings->Personal Tokens and generate a new token.
-   1. Once the token is displayed, make sure to copy it as it won't be shown again.
-1. To get the OKE_AUTH_GROUP
-    1. Use this rest request ```curl -L app.wercker.com/api/v3/identity/lookup?q=<GROUP Name>```
-    1. For example ```curl -L app.wercker.com/api/v3/identity/lookup?q=GAS{"id":"59cae3bd1521710100bc1449","name":"GAS"}```
-    1. The id field value ("59cae3bd1521710100bc1449") reflects OKE_AUTH_GROUP
-1. When logged in to the OCI console, also take note of the Compartment ID. Go to Identity->Compartment and choose the compartment where the instances will be created. Use this information in the cluster's cluster-manager.n6s.io/cluster.config annotation to specify which compartment will be used by the cluster.
+If you are using [Wercker Clusters](http://devcenter.wercker.com/docs/getting-started-with-wercker-clusters#creatingcluster), you need to set the *OKE_CLOUD_AUTH_ID*,  *OKE_BEARER_TOKEN*,  *OKE_AUTH_GROUP*,  and Compartment ID parameters to work with Cluster Manager. If you do not have these parameters, then follow this document to create them.  
+
+1. When you use Wercker Clusters to create a new Kubernetes cluster, you specify Cloud Credentials to specify where you want to create the cluster. If you already have *Cloud Auth ID* and OKE_AUTH_GROUP in the **Clusters > Cloud Credentials** page in the Wercker cluster, you can use those credentials. If you have to create those IDs, then follow these steps:
+<ol type="a">
+<li>Go to https://app.wercker.com/clusters/cloud-credentials and select the Organization.</li>
+<li>Click **New Cloud Credential Button**. </li>
+<li>Enter a name.</li>
+<li>Enter all your Oracle Cloud Infrastructure (OCI) tenancy specific information (User OCID, Tenancy OCID). You can get those information by logging in to [OCI](https://console.us-phoenix-1.oraclecloud.com/) and then by changing the Region, for example, change the region to *us-ashburn-1*. Navigate to Identity and note down the User OCID and also copy the Tenancy ID, which you will find at the bottom of any page in OCI.</li>
+<li>For **Key Fingerprint** and **API Private Key (PEM Format)**, follow the instructions in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.</li>
+<li> Click **Create** and note down the Cloud Auth ID. The Cloud_Auth_ID is displayed in the Cloud Credentials page.</li>
+<li>In the Cloud Credentials page, note down the OKE_AUTH_GROUP, which is the ID displayed next to the Organization drop down list. 
+</ol>
+2. Create a new Wercker authentication token if you do not have one, which will be used for *OKE_BEARER_TOKEN*. See [how to get a Wercker authentication token] (http://devcenter.wercker.com/docs/getting-started-with-wercker-releases#gettingtoken) for more details.
+3. You also need a Compartment ID to specify which compartment the cluster will use. When you log in to the OCI console, go to Identity->Compartment and choose the compartment where the instances will be created. 

--- a/deploy/WerckerClustersParameters.md
+++ b/deploy/WerckerClustersParameters.md
@@ -5,7 +5,7 @@ If you are using [Wercker Clusters](http://devcenter.wercker.com/docs/getting-st
 1. When you use Wercker Clusters to create a new Kubernetes cluster, you specify Cloud Credentials to specify where you want to create the cluster. If you already have *Cloud Auth ID* and OKE_AUTH_GROUP in the **Clusters > Cloud Credentials** page in the Wercker cluster, you can use those credentials. If you have to create those IDs, then follow these steps:
     <ol type="a">
     <li>Go to https://app.wercker.com/clusters/cloud-credentials and select the Organization.</li>
-    <li>Click <B>New Cloud Credential Button</B>. </li>
+    <li>Click <B>New Cloud Credential</B>. </li>
     <li>Enter a name.</li>
     <li>Enter all your Oracle Cloud Infrastructure (OCI) tenancy specific information (User OCID, Tenancy OCID). You can get those information by logging in to [OCI](https://console.us-phoenix-1.oraclecloud.com/) and then by changing the Region, for example, change the region to *us-ashburn-1*. Navigate to Identity and note down the User OCID and also copy the Tenancy ID, which you will find at the bottom of any page in OCI.</li>
     <li>For <B>Key Fingerprint</B> and <B>API Private Key (PEM Format)</B>, follow the instructions in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.</li>

--- a/deploy/WerckerClustersParameters.md
+++ b/deploy/WerckerClustersParameters.md
@@ -3,14 +3,14 @@
 If you are using [Wercker Clusters](http://devcenter.wercker.com/docs/getting-started-with-wercker-clusters#creatingcluster), you need to set the *OKE_CLOUD_AUTH_ID*,  *OKE_BEARER_TOKEN*,  *OKE_AUTH_GROUP*,  and Compartment ID parameters to work with Cluster Manager. If you do not have these parameters, then follow this document to create them.  
 
 1. When you use Wercker Clusters to create a new Kubernetes cluster, you specify Cloud Credentials to specify where you want to create the cluster. If you already have *Cloud Auth ID* and OKE_AUTH_GROUP in the **Clusters > Cloud Credentials** page in the Wercker cluster, you can use those credentials. If you have to create those IDs, then follow these steps:
-<ol type="a">
-<li>Go to https://app.wercker.com/clusters/cloud-credentials and select the Organization.</li>
-<li>Click **New Cloud Credential Button**. </li>
-<li>Enter a name.</li>
-<li>Enter all your Oracle Cloud Infrastructure (OCI) tenancy specific information (User OCID, Tenancy OCID). You can get those information by logging in to [OCI](https://console.us-phoenix-1.oraclecloud.com/) and then by changing the Region, for example, change the region to *us-ashburn-1*. Navigate to Identity and note down the User OCID and also copy the Tenancy ID, which you will find at the bottom of any page in OCI.</li>
-<li>For **Key Fingerprint** and **API Private Key (PEM Format)**, follow the instructions in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.</li>
-<li> Click **Create** and note down the Cloud Auth ID. The Cloud_Auth_ID is displayed in the Cloud Credentials page.</li>
-<li>In the Cloud Credentials page, note down the OKE_AUTH_GROUP, which is the ID displayed next to the Organization drop down list. 
-</ol>
-2. Create a new Wercker authentication token if you do not have one, which will be used for *OKE_BEARER_TOKEN*. See [how to get a Wercker authentication token] (http://devcenter.wercker.com/docs/getting-started-with-wercker-releases#gettingtoken) for more details.
-3. You also need a Compartment ID to specify which compartment the cluster will use. When you log in to the OCI console, go to Identity->Compartment and choose the compartment where the instances will be created. 
+    <ol type="a">
+    <li>Go to https://app.wercker.com/clusters/cloud-credentials and select the Organization.</li>
+    <li>Click **New Cloud Credential Button**. </li>
+    <li>Enter a name.</li>
+    <li>Enter all your Oracle Cloud Infrastructure (OCI) tenancy specific information (User OCID, Tenancy OCID). You can get those information by logging in to [OCI](https://console.us-phoenix-1.oraclecloud.com/) and then by changing the Region, for example, change the region to *us-ashburn-1*. Navigate to Identity and note down the User OCID and also copy the Tenancy ID, which you will find at the bottom of any page in OCI.</li>
+    <li>For **Key Fingerprint** and **API Private Key (PEM Format)**, follow the instructions in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.</li>
+    <li> Click **Create** and note down the Cloud Auth ID. The Cloud_Auth_ID is displayed in the Cloud Credentials page.</li>
+    <li>In the Cloud Credentials page, note down the OKE_AUTH_GROUP, which is the ID displayed next to the Organization drop down list. 
+    </ol>
+1. Create a new Wercker authentication token if you do not have one, which will be used for *OKE_BEARER_TOKEN*. See [how to get a Wercker authentication token] (http://devcenter.wercker.com/docs/getting-started-with-wercker-releases#gettingtoken) for more details.
+1. You also need a Compartment ID to specify which compartment the cluster will use. When you log in to the OCI console, go to Identity->Compartment and choose the compartment where the instances will be created. 

--- a/deploy/WerckerClustersParameters.md
+++ b/deploy/WerckerClustersParameters.md
@@ -5,11 +5,11 @@ If you are using [Wercker Clusters](http://devcenter.wercker.com/docs/getting-st
 1. When you use Wercker Clusters to create a new Kubernetes cluster, you specify Cloud Credentials to specify where you want to create the cluster. If you already have *Cloud Auth ID* and OKE_AUTH_GROUP in the **Clusters > Cloud Credentials** page in the Wercker cluster, you can use those credentials. If you have to create those IDs, then follow these steps:
     <ol type="a">
     <li>Go to https://app.wercker.com/clusters/cloud-credentials and select the Organization.</li>
-    <li>Click **New Cloud Credential Button**. </li>
+    <li>Click <B>New Cloud Credential Button</B>. </li>
     <li>Enter a name.</li>
     <li>Enter all your Oracle Cloud Infrastructure (OCI) tenancy specific information (User OCID, Tenancy OCID). You can get those information by logging in to [OCI](https://console.us-phoenix-1.oraclecloud.com/) and then by changing the Region, for example, change the region to *us-ashburn-1*. Navigate to Identity and note down the User OCID and also copy the Tenancy ID, which you will find at the bottom of any page in OCI.</li>
-    <li>For **Key Fingerprint** and **API Private Key (PEM Format)**, follow the instructions in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.</li>
-    <li> Click **Create** and note down the Cloud Auth ID. The Cloud_Auth_ID is displayed in the Cloud Credentials page.</li>
+    <li>For <B>Key Fingerprint</B> and <B>API Private Key (PEM Format)</B>, follow the instructions in https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.</li>
+    <li> Click <B>Create</B> and note down the Cloud Auth ID. The Cloud_Auth_ID is displayed in the Cloud Credentials page.</li>
     <li>In the Cloud Credentials page, note down the OKE_AUTH_GROUP, which is the ID displayed next to the Organization drop down list. 
     </ol>
 1. Create a new Wercker authentication token if you do not have one, which will be used for *OKE_BEARER_TOKEN*. See [how to get a Wercker authentication token] (http://devcenter.wercker.com/docs/getting-started-with-wercker-releases#gettingtoken) for more details.

--- a/deploy/helm/cluster-manager/templates/deployment.yaml
+++ b/deploy/helm/cluster-manager/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "name" . }}
-  namespace: {{ .Values.federationHostNamespace }}
+  namespace: {{ .Values.federationNamespace }}
 spec:
   replicas: 1
   template:

--- a/deploy/helm/cluster-manager/templates/deployment.yaml
+++ b/deploy/helm/cluster-manager/templates/deployment.yaml
@@ -12,19 +12,34 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}cluster-manager:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}/cluster-manager:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: "{{ .Values.awsAccessKeyId }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "name" . }}-provider-access-keys
+              key: awsAccessKeyId
         - name: AWS_SECRET_ACCESS_KEY
-          value: "{{ .Values.awsSecretAccessKey }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "name" . }}-provider-access-keys
+              key: awsSecretAccessKey
         - name: OKE_BEARER_TOKEN
-          value: "{{ .Values.okeBearerToken }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "name" . }}-provider-access-keys
+              key: okeBearerToken
         - name: OKE_AUTH_GROUP
-          value: "{{ .Values.okeAuthGroup }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "name" . }}-provider-access-keys
+              key: okeAuthGroup
         - name: OKE_CLOUD_AUTH_ID
-          value: "{{ .Values.okeCloudAuthId }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "name" . }}-provider-access-keys
+              key: okeCloudAuthId
         command:
         - /cluster-manager
         {{- if (not (empty .Values.glogLevel)) }}

--- a/deploy/helm/cluster-manager/templates/secret.yaml
+++ b/deploy/helm/cluster-manager/templates/secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "name" . }}-provider-access-keys
+  namespace: {{ .Values.federationNamespace }}
+type: Opaque
+data:
+  {{ if .Values.awsAccessKeyId }}
+  awsAccessKeyId: {{ .Values.awsAccessKeyId | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.awsSecretAccessKey }}
+  awsSecretAccessKey: {{ .Values.awsSecretAccessKey | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.okeBearerToken }}
+  okeBearerToken: {{ .Values.okeBearerToken | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.okeAuthGroup }}
+  okeAuthGroup: {{ .Values.okeAuthGroup | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.okeCloudAuthId }}
+  okeCloudAuthId: {{ .Values.okeCloudAuthId | b64enc | quote }}
+  {{ end }}

--- a/deploy/helm/cluster-manager/values.yaml
+++ b/deploy/helm/cluster-manager/values.yaml
@@ -21,7 +21,7 @@ federationNamespace:
 domain: domain.change.me
 statestore:
 
-# OKE connection paramters
+# OKE connection parameters
 okeApiHost:
 
 # Log Level

--- a/examples/ClusterManager.yaml
+++ b/examples/ClusterManager.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: cluster-manager
-  namespace: federation-system
+  namespace: $FEDERATION_NAMESPACE
 spec:
   replicas: 1
   template:

--- a/examples/ClusterManagerTemplate.yaml
+++ b/examples/ClusterManagerTemplate.yaml
@@ -1,3 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-manager-provider-access-keys
+  namespace: $FEDERATION_NAMESPACE
+type: Opaque
+data:
+  awsAccessKeyId: "$AWS_ACCESS_KEY_ID_BASE64"
+  awsSecretAccessKey: "$AWS_SECRET_ACCESS_KEY_BASE64"
+  okeBearerToken: "$OKE_BEARER_TOKEN_BASE64"
+  okeAuthGroup: "$OKE_AUTH_GROUP_BASE64"
+  okeCloudAuthId: "$OKE_CLOUD_AUTH_ID_BASE64"
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -12,19 +25,34 @@ spec:
     spec:
       containers:
       - name: cluster-manager
-        image: $CLUSTER_MANAGER_IMAGE
+        image: ${IMAGE_REPOSITORY}/cluster-manager:${IMAGE_VERSION}
         imagePullPolicy: Always
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: "$AWS_ACCESS_KEY_ID"
+          valueFrom:
+            secretKeyRef:
+              name: cluster-manager-provider-access-keys
+              key: awsAccessKeyId
         - name: AWS_SECRET_ACCESS_KEY
-          value: "$AWS_SECRET_ACCESS_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: cluster-manager-provider-access-keys
+              key: awsSecretAccessKey
         - name: OKE_BEARER_TOKEN
-          value: "$OKE_BEARER_TOKEN"
+          valueFrom:
+            secretKeyRef:
+              name: cluster-manager-provider-access-keys
+              key: okeBearerToken
         - name: OKE_AUTH_GROUP
-          value: "$OKE_AUTH_GROUP"
+          valueFrom:
+            secretKeyRef:
+              name: cluster-manager-provider-access-keys
+              key: okeAuthGroup
         - name: OKE_CLOUD_AUTH_ID
-          value: "$OKE_CLOUD_AUTH_ID"
+          valueFrom:
+            secretKeyRef:
+              name: cluster-manager-provider-access-keys
+              key: okeCloudAuthId
         command:
         - /cluster-manager
         - --v=2

--- a/pkg/controller/cluster/provider/kopsAws/kops.go
+++ b/pkg/controller/cluster/provider/kopsAws/kops.go
@@ -143,10 +143,9 @@ func init() {
 }
 
 func osLookup(keyId string) error {
-	if value, ok := os.LookupEnv(keyId); !ok {
+	if _, ok := os.LookupEnv(keyId); !ok {
 		return errors.Errorf("%s env is not set, kops provider will be disabled", keyId)
 	} else {
-		glog.Infof("Using %s=%v", keyId, value)
 		return nil
 	}
 }

--- a/pkg/controller/cluster/provider/oke/okebmc.go
+++ b/pkg/controller/cluster/provider/oke/okebmc.go
@@ -119,20 +119,17 @@ func NewOke(config *options.ClusterControllerOptions) (*Oke, error) {
 
 	if bearer, ok := os.LookupEnv(OkeBearerToken); ok {
 		oke.okeBearer = OkeBearerPrefix + bearer
-		glog.Infof("Using OKE_BEARER_TOKEN=%v", oke.okeBearer)
 	} else {
 		return nil, errors.Errorf("Env var %v is required by OKE provider, OKE clusters will not be provisioned", OkeBearerToken)
 	}
 
 	if authGroup, ok := os.LookupEnv(OkeAuthGroup); ok {
 		oke.okeAuthGroup = authGroup
-		glog.Infof("Using OKE_AUTH_GROUP=%v", oke.okeAuthGroup)
 	} else {
 		return nil, errors.Errorf("Env var %v is required by OKE provider, OKE clusters will not be provisioned", OkeAuthGroup)
 	}
 	if defaultCloudAuthId, ok := os.LookupEnv(OkeDefaultCloudAuthId); ok {
 		oke.okeDefaultCloudAuthId = defaultCloudAuthId
-		glog.Infof("Using OKE_CLOUD_AUTH_ID=%v", defaultCloudAuthId)
 	}
 
 	return oke, nil


### PR DESCRIPTION
1. Move API access keys to a secret resource and use them to access with the same environment variable. Helm and ClusterManagerTemplate.yaml are modified for this purpose.
2. Remove display of API access keys in the logs. kops.go and okebmc.go were updated for this purpose
3. Update docs for better instructions and some format issues.